### PR TITLE
Clean currentlyActiveVectorTargetAbility

### DIFF
--- a/content/panorama/scripts/custom_game/vector_targeting.js
+++ b/content/panorama/scripts/custom_game/vector_targeting.js
@@ -177,6 +177,7 @@ function OnVectorTargetingEnd()
 		Particles.DestroyParticleEffect(vectorTargetParticle, true)
 		vectorTargetParticle = undefined;
 		vectorTargetUnit = undefined;
+		currentlyActiveVectorTargetAbility = undefined;
 	}
 }
 


### PR DESCRIPTION
Casting an item immediately after a vector targeted ability causes the item to have the vector targeting regardless of its behavior. Cleaning the variable in vectortargetend fixes the problem and doesn't seem to cause regression elsewhere.

Tested with Pangolier, maybe should be tested with a hero with multiple vector targeted spells