### PR TITLE
Refine targeting end condition

### DIFF
--- a/content/panorama/scripts/custom_game/vector_targeting.js
+++ b/content/panorama/scripts/custom_game/vector_targeting.js
@@ -26,7 +26,6 @@ GameUI.SetMouseCallback(function(eventName, arg, arg2, arg3)
 	if(GameUI.GetClickBehaviors() == 3 && currentlyActiveVectorTargetAbility != undefined){
 		const netTable = CustomNetTables.GetTableValue( "vector_targeting", currentlyActiveVectorTargetAbility )
 		OnVectorTargetingStart(netTable.startWidth, netTable.endWidth, netTable.castLength, netTable.dual, netTable.ignoreArrow);
-		currentlyActiveVectorTargetAbility = undefined;
 	}
 	return CONTINUE_PROCESSING_EVENT;
 });

--- a/content/panorama/scripts/custom_game/vector_targeting.js
+++ b/content/panorama/scripts/custom_game/vector_targeting.js
@@ -56,7 +56,7 @@ function CheckAbilityVectorTargeting(panel){
 			if(GameUI.GetClickBehaviors() == 9 ){
 				OnVectorTargetingStart(netTable.startWidth, netTable.endWidth, netTable.castLength, netTable.dual, netTable.ignoreArrow);
 			}
-		} else {
+		} else if (abilityIndex == currentlyActiveVectorTargetAbility) {
 			OnVectorTargetingEnd();
 		}
 	}


### PR DESCRIPTION
I know last commit was 3 years ago, but people are still referencing this library, so at least it stays somewhere. 

This change fixes bug when there are several vector targeting abilities on the panel and update in one other ability (i.e. cooldown end) influences state of ability actually being targeted (destroys target particle).